### PR TITLE
Fixed Bug #7298, where Quip accepted ` in comment

### DIFF
--- a/core/components/quip/model/quip/quip.class.php
+++ b/core/components/quip/model/quip/quip.class.php
@@ -452,7 +452,7 @@ class Quip {
         // this causes double quotes on a href tags; commenting out for now
         //$body = str_replace(array('"',"'"),array('&quot;','&apos;'),$body);
         /* replace MODx tags with entities */
-        $body = str_replace(array('[',']'),array('&#91;','&#93;'),$body);
+        $body = str_replace(array('[',']','`'),array('&#91;','&#93;','&#96;'),$body);
 
         return $body;
     }


### PR DESCRIPTION
Replacing the `  char with numeric code &amp;#96;
