### PR TITLE
Fix the bugfix.

### DIFF
--- a/core/components/quip/controllers/web/LatestComments.php
+++ b/core/components/quip/controllers/web/LatestComments.php
@@ -88,10 +88,10 @@ class QuipLatestCommentsController extends QuipController {
 
                 if (!empty($stripTags)) {
                     $commentArray['body'] = strip_tags($commentArray['body']);
-                    $commentArray['ago'] = $this->quip->getTimeAgo($commentArray['createdon']);
-                    $output[] = $this->quip->getChunk($tpl,$commentArray);
-                    $alt = !$alt;
                 }
+                $commentArray['ago'] = $this->quip->getTimeAgo($commentArray['createdon']);
+                $output[] = $this->quip->getChunk($tpl,$commentArray);
+                $alt = !$alt;
             }
 
             $pagePlaceholders['resource'] = $commentArray['resource'];


### PR DESCRIPTION
Prepare the output even if $striptags is not set (wherever it should be
set. Did not find that.)

Quite sever problem because latest_comments do not show up currently. Sorry for messing that up.

Shows that even small thing can go awry. Happened when i had to move the
changes from my running modx code into my quip checkout.

I hope there is a better way.
