### PR TITLE
Fix an issue where preHooks were resulting in empty comments.

### DIFF
--- a/core/components/quip/processors/web/comment/create.php
+++ b/core/components/quip/processors/web/comment/create.php
@@ -87,7 +87,7 @@ $fields['body'] = str_replace(array('<br><br>','<br /><br />'),'',nl2br($fields[
 
 /* run preHooks */
 $quip->loadHooks('pre');
-$quip->preHooks->loadMultiple($this->getProperty('preHooks',''),$this->getProperties(),array(
+$quip->preHooks->loadMultiple($this->getProperty('preHooks',''),$fields,array(
     'hooks' => $this->getProperty('preHooks',''),
 ));
 


### PR DESCRIPTION
When created a custom preHook which would simply "return true;", the comments which got created were empty, and an error message appeared in logs:

```
[Sat Jun 23 12:33:22 2012] [error] [client 127.0.0.1] PHP Notice:  Undefined index: body in /home/yurb/public_html/modx/core/components/quip/processors/web/comment/create.php on line 120, referer: http://modx.proj/
```

A fix was suggested here:
http://forums.modx.com/thread/76629/quip---add-simple-anti-spam-field#dis-post-423933
