### PR TITLE
Move Ext.onReady calls to controllers

### DIFF
--- a/assets/components/quip/js/sections/home.js
+++ b/assets/components/quip/js/sections/home.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({ xtype: 'quip-page-home'});
-});
-
 Quip.page.Home = function(config) {
     config = config || {};
     Ext.applyIf(config,{

--- a/assets/components/quip/js/sections/thread.js
+++ b/assets/components/quip/js/sections/thread.js
@@ -1,10 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({ 
-        xtype: 'quip-page-thread'
-        ,thread: MODx.request.thread
-    });
-});
-
 Quip.page.Thread = function(config) {
     config = config || {};
     Ext.applyIf(config,{

--- a/core/components/quip/controllers/home.class.php
+++ b/core/components/quip/controllers/home.class.php
@@ -31,6 +31,7 @@ class QuipHomeManagerController extends QuipManagerController {
         $this->addJavascript($this->quip->config['jsUrl'].'widgets/comments.grid.js');
         $this->addJavascript($this->quip->config['jsUrl'].'widgets/threads.panel.js');
         $this->addLastJavascript($this->quip->config['jsUrl'].'sections/home.js');
+        $this->addHtml("<script>Ext.onReady(function() { MODx.load({xtype: 'quip-page-home'}) })</script>");
     }
     public function getTemplateFile() { return $this->quip->config['templatesPath'].'home.tpl'; }
 }

--- a/core/components/quip/controllers/thread.class.php
+++ b/core/components/quip/controllers/thread.class.php
@@ -32,6 +32,7 @@ class QuipThreadManagerController extends QuipManagerController {
         $this->addJavascript($this->quip->config['jsUrl'].'widgets/notifications.grid.js');
         $this->addJavascript($this->quip->config['jsUrl'].'widgets/thread.panel.js');
         $this->addLastJavascript($this->quip->config['jsUrl'].'sections/thread.js');
+        $this->addHtml("<script>Ext.onReady(function() { MODx.load({xtype: 'quip-page-thread', thread: MODx.request.thread}) })</script>");
     }
     public function getTemplateFile() { return $this->quip->config['templatesPath'].'thread.tpl'; }
 }


### PR DESCRIPTION
This path makes Quip ready for XHR loading, for example using AjaxManager plugin.
