### PR TITLE
Update core/components/quip/controllers/web/ThreadReply.php

### DIFF
--- a/core/components/quip/controllers/web/ThreadReply.php
+++ b/core/components/quip/controllers/web/ThreadReply.php
@@ -140,7 +140,7 @@ class QuipThreadReplyController extends QuipController {
         
         /* handle POST */
         $this->hasPreview = false;
-        if (!empty($_POST)) {
+        if (!empty($_POST) && !empty($_POST[$this->getProperty('postAction','quip-post')])) {
             $this->handlePost();
         }
         


### PR DESCRIPTION
fix issue when QuipReply receive not empty $_POST but without postAction and return errors with empty fields: name, email etc... 
