### PR TITLE
Fixed connector crash on not existing object

### DIFF
--- a/core/components/quip/model/quip/quipcomment.class.php
+++ b/core/components/quip/model/quip/quipcomment.class.php
@@ -108,6 +108,7 @@ class quipComment extends xPDOSimpleObject {
             $options['context_key'] = $this->get('context_key');
             if (empty($options['context_key'])) {
                 $modresource = $this->xpdo->getObject('modResource', $resource);
+                if (!$modresource) return "Javascript: alert('Commeted object is lost! You can delete this comment.')";
                 $options['context_key'] = $modresource->get('context_key');
             }
         }


### PR DESCRIPTION
Article comments connector crashes if article is absent while comment still exist and need to be moderated. Crash happens when connector tries to create URL for not existing object and it just throws error. So i made a trick - returning JS alert in url. I think it's much better when just crash :)

How to get error happen - delete resource from DB which has new comments and try to get comments for moderation in manager. connector will crash.
