### PR TITLE
Fixes bug with debug=1 system setting

### DIFF
--- a/core/components/quip/model/quip/quip.class.php
+++ b/core/components/quip/model/quip/quip.class.php
@@ -125,11 +125,21 @@ class Quip {
      */
     public function initDebug() {
         if ($this->modx->getOption('debug',$this->config,false)) {
-            error_reporting(E_ALL); ini_set('display_errors',true);
-            $this->modx->setLogTarget('HTML');
-            $this->modx->setLogLevel(modX::LOG_LEVEL_ERROR);
+            //error_reporting(E_ALL); 
+            //ini_set('display_errors',true);
+            //$this->modx->setLogTarget('HTML');
+            //$this->modx->setLogLevel(modX::LOG_LEVEL_ERROR);
 
-            $debugUser = $this->config['debugUser'] == '' ? $this->modx->user->get('username') : 'anonymous';
+            /* BUG: original code throws an error, when debugUser has not been set. Together with the (wrong) error 
+                reporting settings above this caused the manager to be unusable in debug mode
+            */
+            $debugUser = 'anonymous';
+            if (isset($this->config['debugUser'])) {
+                if ($this->config['debugUser'] == '') {
+                    $debugUser = $this->modx->user->get('username');
+                }
+            } 
+            
             $user = $this->modx->getObject('modUser',array('username' => $debugUser));
             if ($user == null) {
                 $this->modx->user->set('id',$this->modx->getOption('debugUserId',$this->config,1));


### PR DESCRIPTION
When you have debug=1 in system settings, manager pages with quip components are broken. This is due to the lines 128-131, which change the set error behaviour of your system (NEVER put out errors to HTML...). 
The revealing error was the access to config['debugUser'], which may not be set. This throws the error 

```
Notice: Undefined index: debugUser in /core/components/quip/model/quip/quip.class.php on line 132
```

This error was already reported at http://bugs.modx.com/issues/8467 and on other places, but was never corrected.
