### PR TITLE
Fixed PHP-type for quipComment - "body" field

### DIFF
--- a/core/components/quip/controllers/web/Thread.php
+++ b/core/components/quip/controllers/web/Thread.php
@@ -333,7 +333,12 @@ class QuipThreadController extends QuipController {
     public function handleActions() {
         /* handle remove post */
         $removeAction = $this->getProperty('removeAction','quip-remove');
-        if (!empty($_REQUEST[$removeAction]) && $this->hasAuth && $this->isModerator) {
+
+        /* handle author remove their own comment even when they are not moderator */
+        $currentComment = $this->getComments()[(int)$_REQUEST['quip_comment']];
+
+        if (!empty($_REQUEST[$removeAction]) && $this->hasAuth && ($this->isModerator
+				|| (!empty($currentComment) && $currentComment->get('author') == $this->modx->user->get('id')))) {
             $this->removeComment();
         }
         /* handle report spam */

--- a/core/components/quip/model/quip/mysql/quipcomment.map.inc.php
+++ b/core/components/quip/model/quip/mysql/quipcomment.map.inc.php
@@ -90,7 +90,7 @@ $xpdo_meta_map['quipComment']= array (
     'body' => 
     array (
       'dbtype' => 'text',
-      'phptype' => 'text',
+      'phptype' => 'string',
       'null' => false,
       'default' => '',
     ),

--- a/core/components/quip/model/quip/sqlsrv/quipcomment.map.inc.php
+++ b/core/components/quip/model/quip/sqlsrv/quipcomment.map.inc.php
@@ -89,7 +89,7 @@ $xpdo_meta_map['quipComment']= array (
     array (
       'dbtype' => 'nvarchar',
       'precision' => 'max',
-      'phptype' => 'text',
+      'phptype' => 'string',
       'null' => false,
       'default' => '',
     ),

--- a/core/components/quip/model/schema/quip.mysql.schema.xml
+++ b/core/components/quip/model/schema/quip.mysql.schema.xml
@@ -45,7 +45,7 @@
         <field key="rank" dbtype="tinytext" phptype="string" />
         
         <field key="author" dbtype="integer" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" index="index" />
-        <field key="body" dbtype="text" phptype="text" null="false" default="" />
+        <field key="body" dbtype="text" phptype="string" null="false" default="" />
         <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
         <field key="editedon" dbtype="datetime" phptype="datetime" null="true" />
         <field key="approved" dbtype="tinyint" precision="1" phptype="boolean" attributes="unsigned" null="false" default="1" index="index" /> 

--- a/core/components/quip/model/schema/quip.sqlsrv.schema.xml
+++ b/core/components/quip/model/schema/quip.sqlsrv.schema.xml
@@ -48,7 +48,7 @@
         <field key="rank" dbtype="nvarchar" precision="512" phptype="string" />
 
         <field key="author" dbtype="integer" phptype="integer" null="false" default="0" index="index" />
-        <field key="body" dbtype="nvarchar" precision="max" phptype="text" null="false" default="" />
+        <field key="body" dbtype="nvarchar" precision="max" phptype="string" null="false" default="" />
         <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
         <field key="editedon" dbtype="datetime" phptype="datetime" null="true" />
         <field key="approved" dbtype="bit" phptype="boolean" null="false" default="1" index="index" />


### PR DESCRIPTION
It surprises me but somehow this bug did not have any effect until recently. Maybe MySQL started to check more strict on `PARAM_TYPE`, maybe something changed in xPDO core.
However, the _body_ field had it's `phptype` set to `"text"` which doesn't exist. Effectively it was set to PARAM_INT.